### PR TITLE
feat(no_issue): add environment to the automated commit message

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
-          title: "chore(noticket): bump image version to ${{ inputs.image_tag }}"
+          title: "chore(noticket): ${{ inputs.helm_release_name }} version ${{ inputs.image_tag }} deployed to ${{ inputs.k8s_environment }}"
           body: |
             Version bump to ${{ inputs.image_tag }} after successful helm deployment
             NOTE: this is an automated PR by the create-pull-request GitHub action


### PR DESCRIPTION
Add the environment to the automatically generated commit message.

It goes from:
> chore(noticket): bump image version to 1.17.1

To:
> chore(noticket): pensieve version 1.17.1 deployed to dev